### PR TITLE
feat: add AsyncAPI endpoints to FastAPI plugin

### DIFF
--- a/faststream/_compat.py
+++ b/faststream/_compat.py
@@ -13,6 +13,7 @@ from pydantic import BaseModel
 #     from typing_extensions import override as override
 # else:
 #     from typing import override
+from typing_extensions import Required as Required
 from typing_extensions import TypedDict as TypedDict
 from typing_extensions import override as override
 

--- a/faststream/asyncapi/generate.py
+++ b/faststream/asyncapi/generate.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict
+from typing import Any, Dict, Union
 
 from faststream.app import FastStream
 from faststream.asyncapi.schema import (
@@ -6,13 +6,15 @@ from faststream.asyncapi.schema import (
     Components,
     Info,
     Message,
+    Reference,
     Schema,
     Server,
 )
+from faststream.broker.fastapi.router import StreamRouter
 from faststream.constants import ContentTypes
 
 
-def get_app_schema(app: FastStream) -> Schema:
+def get_app_schema(app: Union[FastStream, StreamRouter[Any]]) -> Schema:
     servers = get_app_broker_server(app)
     channels = get_app_broker_channels(app)
 
@@ -24,30 +26,32 @@ def get_app_schema(app: FastStream) -> Schema:
         if ch.subscribe is not None:
             m = ch.subscribe.message
 
-            p = m.payload
-            p_title = p.get("title", f"{channel_name}Payload")
-            payloads[p_title] = p
-            m.payload = {"$ref": f"#/components/schemas/{p_title}"}
+            if isinstance(m, Message):
+                p = m.payload
+                p_title = p.get("title", f"{channel_name}Payload")
+                payloads[p_title] = p
+                m.payload = {"$ref": f"#/components/schemas/{p_title}"}
 
-            assert m.title
-            messages[m.title] = m
-            ch.subscribe.message = {
-                "$ref": f"#/components/messages/{m.title}"
-            }  # type: ignore
+                assert m.title
+                messages[m.title] = m
+                ch.subscribe.message = Reference(
+                    **{"$ref": f"#/components/messages/{m.title}"}
+                )
 
         if ch.publish is not None:
             m = ch.publish.message
 
-            p = m.payload
-            p_title = p.get("title", f"{channel_name}Payload")
-            payloads[p_title] = p
-            m.payload = {"$ref": f"#/components/schemas/{p_title}"}
+            if isinstance(m, Message):
+                p = m.payload
+                p_title = p.get("title", f"{channel_name}Payload")
+                payloads[p_title] = p
+                m.payload = {"$ref": f"#/components/schemas/{p_title}"}
 
-            assert m.title
-            messages[m.title] = m
-            ch.publish.message = {
-                "$ref": f"#/components/messages/{m.title}"
-            }  # type: ignore
+                assert m.title
+                messages[m.title] = m
+                ch.publish.message = Reference(
+                    **{"$ref": f"#/components/messages/{m.title}"}
+                )
 
     schema = Schema(
         info=Info(
@@ -72,7 +76,9 @@ def get_app_schema(app: FastStream) -> Schema:
     return schema
 
 
-def get_app_broker_server(app: FastStream) -> Dict[str, Server]:
+def get_app_broker_server(
+    app: Union[FastStream, StreamRouter[Any]]
+) -> Dict[str, Server]:
     servers = {}
 
     broker = app.broker
@@ -105,7 +111,9 @@ def get_app_broker_server(app: FastStream) -> Dict[str, Server]:
     return servers
 
 
-def get_app_broker_channels(app: FastStream) -> Dict[str, Channel]:
+def get_app_broker_channels(
+    app: Union[FastStream, StreamRouter[Any]]
+) -> Dict[str, Channel]:
     channels = {}
     assert app.broker
 

--- a/faststream/asyncapi/schema/__init__.py
+++ b/faststream/asyncapi/schema/__init__.py
@@ -19,6 +19,7 @@ from faststream.asyncapi.schema.servers import Server
 from faststream.asyncapi.schema.utils import (
     ExternalDocs,
     ExternalDocsDict,
+    Reference,
     Tag,
     TagDict,
 )
@@ -43,6 +44,7 @@ __all__ = (
     "TagDict",
     "ExternalDocs",
     "ExternalDocsDict",
+    "Reference",
     # bindings
     "ServerBinding",
     "ChannelBinding",

--- a/faststream/asyncapi/schema/info.py
+++ b/faststream/asyncapi/schema/info.py
@@ -7,6 +7,7 @@ from faststream._compat import (
     CoreSchema,
     GetJsonSchemaHandler,
     JsonSchemaValue,
+    Required,
     TypedDict,
     general_plain_validator_function,
     is_installed,
@@ -57,7 +58,7 @@ else:  # pragma: no cover
 
 
 class ContactDict(TypedDict, total=False):
-    name: str
+    name: Required[str]
     url: AnyHttpUrl
     email: EmailStr
 
@@ -77,7 +78,7 @@ class Contact(BaseModel):
 
 
 class LicenseDict(TypedDict, total=False):
-    name: str
+    name: Required[str]
     url: AnyHttpUrl
 
 

--- a/faststream/asyncapi/schema/info.py
+++ b/faststream/asyncapi/schema/info.py
@@ -58,8 +58,8 @@ else:  # pragma: no cover
 
 class ContactDict(TypedDict, total=False):
     name: str
-    url: Optional[AnyHttpUrl]
-    email: Optional[EmailStr]
+    url: AnyHttpUrl
+    email: EmailStr
 
 
 class Contact(BaseModel):
@@ -78,7 +78,7 @@ class Contact(BaseModel):
 
 class LicenseDict(TypedDict, total=False):
     name: str
-    url: Optional[AnyHttpUrl]
+    url: AnyHttpUrl
 
 
 class License(BaseModel):

--- a/faststream/asyncapi/schema/main.py
+++ b/faststream/asyncapi/schema/main.py
@@ -68,3 +68,12 @@ class Schema(BaseModel):
             by_alias=True,
             exclude_none=True,
         )
+
+    def to_yaml(self) -> str:
+        from io import StringIO
+
+        import yaml
+
+        io = StringIO(initial_value="", newline="\n")
+        yaml.dump(self.to_jsonable(), io, sort_keys=False)
+        return io.getvalue()

--- a/faststream/asyncapi/schema/operations.py
+++ b/faststream/asyncapi/schema/operations.py
@@ -8,6 +8,7 @@ from faststream.asyncapi.schema.message import Message
 from faststream.asyncapi.schema.utils import (
     ExternalDocs,
     ExternalDocsDict,
+    Reference,
     Tag,
     TagDict,
 )
@@ -20,7 +21,7 @@ class Operation(BaseModel):
 
     bindings: Optional[OperationBinding] = None
 
-    message: Message
+    message: Union[Message, Reference]
 
     security: Optional[Dict[str, List[str]]] = None
 

--- a/faststream/asyncapi/schema/utils.py
+++ b/faststream/asyncapi/schema/utils.py
@@ -7,7 +7,7 @@ from faststream._compat import PYDANTIC_V2, TypedDict
 
 class ExternalDocsDict(TypedDict, total=False):
     url: AnyHttpUrl
-    description: Optional[str]
+    description: str
 
 
 class ExternalDocs(BaseModel):
@@ -25,8 +25,8 @@ class ExternalDocs(BaseModel):
 
 class TagDict(TypedDict, total=False):
     name: str
-    description: Optional[str]
-    externalDocs: Optional[Union[ExternalDocs, ExternalDocsDict]]
+    description: str
+    externalDocs: Union[ExternalDocs, ExternalDocsDict]
 
 
 class Tag(BaseModel):

--- a/faststream/asyncapi/schema/utils.py
+++ b/faststream/asyncapi/schema/utils.py
@@ -2,11 +2,11 @@ from typing import Optional, Union
 
 from pydantic import AnyHttpUrl, BaseModel, Field
 
-from faststream._compat import PYDANTIC_V2, TypedDict
+from faststream._compat import PYDANTIC_V2, Required, TypedDict
 
 
 class ExternalDocsDict(TypedDict, total=False):
-    url: AnyHttpUrl
+    url: Required[AnyHttpUrl]
     description: str
 
 
@@ -24,7 +24,7 @@ class ExternalDocs(BaseModel):
 
 
 class TagDict(TypedDict, total=False):
-    name: str
+    name: Required[str]
     description: str
     externalDocs: Union[ExternalDocs, ExternalDocsDict]
 

--- a/faststream/broker/core/abc.py
+++ b/faststream/broker/core/abc.py
@@ -37,6 +37,7 @@ from faststream.broker.types import (
     ConnectionType,
     CustomDecoder,
     CustomParser,
+    Filter,
     MsgType,
     P_HandlerParams,
     T_HandlerReturn,
@@ -80,7 +81,7 @@ class BrokerUsecase(
         protocol: str,
         protocol_version: Optional[str] = None,
         description: Optional[str] = None,
-        tags: Optional[Sequence[asyncapi.Tag]] = None,
+        tags: Optional[Sequence[Union[asyncapi.Tag, asyncapi.TagDict]]] = None,
         # broker kwargs
         apply_types: bool = True,
         logger: Optional[logging.Logger] = access_logger,
@@ -269,9 +270,7 @@ class BrokerUsecase(
                 ]
             ]
         ] = None,
-        filter: Callable[
-            [StreamMessage[MsgType]], Union[bool, Awaitable[bool]]
-        ] = lambda m: not m.processed,
+        filter: Filter[StreamMessage[MsgType]] = lambda m: not m.processed,
         _raw: bool = False,
         _get_dependant: Optional[Any] = None,
         **broker_kwargs: Any,

--- a/faststream/broker/router.py
+++ b/faststream/broker/router.py
@@ -17,8 +17,8 @@ from fast_depends.dependencies import Depends
 from faststream.broker.message import StreamMessage
 from faststream.broker.publisher import BasePublisher
 from faststream.broker.types import (
-    AsyncCustomDecoder,
-    AsyncCustomParser,
+    CustomDecoder,
+    CustomParser,
     MsgType,
     P_HandlerParams,
     T_HandlerReturn,
@@ -76,8 +76,8 @@ class BrokerRouter(Generic[PublisherKeyType, MsgType]):
                 ]
             ]
         ] = None,
-        parser: Optional[AsyncCustomParser[MsgType]] = None,
-        decoder: Optional[AsyncCustomDecoder[MsgType]] = None,
+        parser: Optional[CustomParser[MsgType]] = None,
+        decoder: Optional[CustomDecoder[MsgType]] = None,
     ):
         self.prefix = prefix
         self._handlers = list(handlers)
@@ -101,8 +101,8 @@ class BrokerRouter(Generic[PublisherKeyType, MsgType]):
                 ]
             ]
         ] = None,
-        parser: Optional[AsyncCustomParser[MsgType]] = None,
-        decoder: Optional[AsyncCustomDecoder[MsgType]] = None,
+        parser: Optional[CustomParser[MsgType]] = None,
+        decoder: Optional[CustomDecoder[MsgType]] = None,
         **kwargs: Any,
     ) -> Callable[
         [Callable[P_HandlerParams, T_HandlerReturn]],
@@ -122,8 +122,8 @@ class BrokerRouter(Generic[PublisherKeyType, MsgType]):
                 ]
             ]
         ] = None,
-        parser: Optional[AsyncCustomParser[MsgType]] = None,
-        decoder: Optional[AsyncCustomDecoder[MsgType]] = None,
+        parser: Optional[CustomParser[MsgType]] = None,
+        decoder: Optional[CustomDecoder[MsgType]] = None,
         **kwargs: Any,
     ) -> Callable[
         [Callable[P_HandlerParams, T_HandlerReturn]],

--- a/faststream/broker/types.py
+++ b/faststream/broker/types.py
@@ -8,22 +8,34 @@ Decoded = TypeVar("Decoded", bound=DecodedMessage)
 MsgType = TypeVar("MsgType")
 ConnectionType = TypeVar("ConnectionType")
 
+SyncFilter = Callable[[MsgType], bool]
+AsyncFilter = Callable[[MsgType], Awaitable[bool]]
+Filter = Union[SyncFilter[MsgType], AsyncFilter[MsgType]]
+
 SyncParser = Callable[
     [MsgType],
     StreamMessage[MsgType],
 ]
+SyncCustomParser = Union[
+    SyncParser[MsgType],
+    Callable[
+        [MsgType, SyncParser[MsgType]],
+        StreamMessage[MsgType],
+    ],
+]
+
 AsyncParser = Callable[
     [MsgType],
     Awaitable[StreamMessage[MsgType]],
 ]
-SyncCustomParser = Callable[
-    [MsgType, SyncParser[MsgType]],
-    StreamMessage[MsgType],
+AsyncCustomParser = Union[
+    AsyncParser[MsgType],
+    Callable[
+        [MsgType, AsyncParser[MsgType]],
+        Awaitable[StreamMessage[MsgType]],
+    ],
 ]
-AsyncCustomParser = Callable[
-    [MsgType, SyncParser[MsgType]],
-    Awaitable[StreamMessage[MsgType]],
-]
+
 Parser = Union[AsyncParser[MsgType], SyncParser[MsgType]]
 CustomParser = Union[AsyncCustomParser[MsgType], SyncCustomParser[MsgType]]
 
@@ -31,20 +43,28 @@ SyncDecoder = Callable[
     [StreamMessage[MsgType]],
     DecodedMessage,
 ]
-SyncCustomDecoder = Callable[
-    [StreamMessage[MsgType], SyncDecoder[MsgType]],
-    DecodedMessage,
+SyncCustomDecoder = Union[
+    SyncDecoder[MsgType],
+    Callable[
+        [StreamMessage[MsgType], SyncDecoder[MsgType]],
+        DecodedMessage,
+    ],
 ]
+
 AsyncDecoder = Callable[
     [
         StreamMessage[MsgType],
     ],
     Awaitable[DecodedMessage],
 ]
-AsyncCustomDecoder = Callable[
-    [StreamMessage[MsgType], AsyncDecoder[MsgType]],
-    Awaitable[DecodedMessage],
+AsyncCustomDecoder = Union[
+    AsyncDecoder[MsgType],
+    Callable[
+        [StreamMessage[MsgType], AsyncDecoder[MsgType]],
+        Awaitable[DecodedMessage],
+    ],
 ]
+
 Decoder = Union[AsyncDecoder[MsgType], SyncDecoder[MsgType]]
 CustomDecoder = Union[AsyncCustomDecoder[MsgType], SyncCustomDecoder[MsgType]]
 

--- a/faststream/kafka/broker.py
+++ b/faststream/kafka/broker.py
@@ -9,6 +9,7 @@ from typing import (
     Literal,
     Optional,
     Sequence,
+    Tuple,
     Type,
     Union,
 )
@@ -25,23 +26,22 @@ from faststream.broker.message import StreamMessage
 from faststream.broker.middlewares import BaseMiddleware
 from faststream.broker.push_back_watcher import BaseWatcher, WatcherContext
 from faststream.broker.types import (
-    AsyncCustomDecoder,
-    AsyncCustomParser,
     AsyncPublisherProtocol,
+    CustomDecoder,
+    CustomParser,
+    Filter,
     P_HandlerParams,
     T_HandlerReturn,
     WrappedReturn,
 )
 from faststream.broker.wrapper import FakePublisher, HandlerCallWrapper
 from faststream.kafka.asyncapi import Handler, Publisher
+from faststream.kafka.message import KafkaMessage
 from faststream.kafka.producer import AioKafkaFastProducer
 from faststream.kafka.shared.logging import KafkaLoggingMixin
 from faststream.kafka.shared.schemas import ConsumerConnectionParams
 from faststream.utils import context
 from faststream.utils.data import filter_by_dict
-from faststream.utils.functions import to_async
-
-KafkaMessage = StreamMessage[aiokafka.ConsumerRecord]
 
 
 class KafkaBroker(
@@ -105,8 +105,6 @@ class KafkaBroker(
         await producer.start()
         self._producer = AioKafkaFastProducer(
             producer=producer,
-            decoder=self._global_decoder,
-            parser=self._global_parser,
         )
         return filter_by_dict(ConsumerConnectionParams, kwargs)
 
@@ -184,8 +182,18 @@ class KafkaBroker(
         ] = "read_uncommitted",
         # broker arguments
         dependencies: Sequence[Depends] = (),
-        parser: Optional[AsyncCustomParser[aiokafka.ConsumerRecord]] = None,
-        decoder: Optional[AsyncCustomDecoder[aiokafka.ConsumerRecord]] = None,
+        parser: Optional[
+            Union[
+                CustomParser[aiokafka.ConsumerRecord],
+                CustomParser[Tuple[aiokafka.ConsumerRecord, ...]],
+            ]
+        ] = None,
+        decoder: Optional[
+            Union[
+                CustomDecoder[aiokafka.ConsumerRecord],
+                CustomDecoder[Tuple[aiokafka.ConsumerRecord, ...]],
+            ]
+        ] = None,
         middlewares: Optional[
             Sequence[
                 Callable[
@@ -195,7 +203,8 @@ class KafkaBroker(
             ]
         ] = None,
         filter: Union[
-            Callable[[KafkaMessage], bool], Callable[[KafkaMessage], Awaitable[bool]]
+            Filter[KafkaMessage],
+            Filter[StreamMessage[Tuple[aiokafka.ConsumerRecord, ...]]],
         ] = default_filter,
         batch: bool = False,
         max_records: Optional[int] = None,
@@ -206,7 +215,14 @@ class KafkaBroker(
         **original_kwargs: Any,
     ) -> Callable[
         [Callable[P_HandlerParams, T_HandlerReturn]],
-        HandlerCallWrapper[aiokafka.ConsumerRecord, P_HandlerParams, T_HandlerReturn],
+        Union[
+            HandlerCallWrapper[
+                aiokafka.ConsumerRecord, P_HandlerParams, T_HandlerReturn
+            ],
+            HandlerCallWrapper[
+                Tuple[aiokafka.ConsumerRecord, ...], P_HandlerParams, T_HandlerReturn
+            ],
+        ],
     ]:
         super().subscriber()
 
@@ -266,7 +282,7 @@ class KafkaBroker(
 
             handler.add_call(
                 handler=handler_call,
-                filter=to_async(filter),
+                filter=filter,
                 middlewares=middlewares,
                 parser=parser or self._global_parser,
                 decoder=decoder or self._global_decoder,

--- a/faststream/kafka/fastapi.pyi
+++ b/faststream/kafka/fastapi.pyi
@@ -31,6 +31,7 @@ from fastapi.utils import generate_unique_id
 from kafka.coordinator.assignors.abstract import AbstractPartitionAssignor
 from kafka.coordinator.assignors.roundrobin import RoundRobinPartitionAssignor
 from kafka.partitioner.default import DefaultPartitioner
+from pydantic import AnyHttpUrl
 from starlette import routing
 from starlette.responses import JSONResponse, Response
 from starlette.types import AppType, ASGIApp
@@ -52,6 +53,7 @@ from faststream.broker.wrapper import HandlerCallWrapper
 from faststream.kafka.asyncapi import Publisher
 from faststream.kafka.broker import KafkaBroker
 from faststream.log import access_logger
+from faststream.types import AnyDict
 
 KafkaMessage = StreamMessage[aiokafka.ConsumerRecord]
 Partition = TypeVar("Partition")
@@ -135,11 +137,25 @@ class KafkaRouter(StreamRouter[ConsumerRecord]):
                 ]
             ]
         ] = None,
-        # AsyncAPI information
-        protocol: str = "kafka",
-        protocol_version: str = "auto",
-        description: Optional[str] = None,
-        asyncapi_tags: Optional[Sequence[asyncapi.Tag]] = None,
+        # AsyncAPI args
+        title: str = "FastStream",
+        version: str = "0.1.0",
+        description: str = "",
+        terms_of_service: Optional[AnyHttpUrl] = None,
+        license: Optional[
+            Union[asyncapi.License, asyncapi.LicenseDict, AnyDict]
+        ] = None,
+        contact: Optional[
+            Union[asyncapi.Contact, asyncapi.ContactDict, AnyDict]
+        ] = None,
+        identifier: Optional[str] = None,
+        asyncapi_tags: Optional[
+            List[Union[asyncapi.Tag, asyncapi.TagDict, AnyDict]]
+        ] = None,
+        external_docs: Optional[
+            Union[asyncapi.ExternalDocs, asyncapi.ExternalDocsDict, AnyDict]
+        ] = None,
+        schema_url: Optional[str] = "/asyncapi",
         # logging args
         logger: Optional[logging.Logger] = access_logger,
         log_level: int = logging.INFO,

--- a/faststream/kafka/producer.py
+++ b/faststream/kafka/producer.py
@@ -1,33 +1,20 @@
 from typing import Dict, Optional
 from uuid import uuid4
 
-from aiokafka import AIOKafkaProducer, ConsumerRecord
+from aiokafka import AIOKafkaProducer
 
-from faststream.broker.parsers import encode_message, resolve_custom_func
-from faststream.broker.types import (
-    AsyncCustomDecoder,
-    AsyncCustomParser,
-    AsyncDecoder,
-    AsyncParser,
-)
-from faststream.kafka.parser import AioKafkaParser
+from faststream.broker.parsers import encode_message
 from faststream.types import SendableMessage
 
 
 class AioKafkaFastProducer:
     _producer: Optional[AIOKafkaProducer]
-    _decoder: AsyncDecoder[ConsumerRecord]
-    _parser: AsyncParser[ConsumerRecord]
 
     def __init__(
         self,
         producer: AIOKafkaProducer,
-        parser: Optional[AsyncCustomParser[ConsumerRecord]],
-        decoder: Optional[AsyncCustomDecoder[ConsumerRecord]],
     ):
         self._producer = producer
-        self._parser = resolve_custom_func(parser, AioKafkaParser.parse_message)
-        self._decoder = resolve_custom_func(decoder, AioKafkaParser.decode_message)
 
     async def publish(
         self,

--- a/faststream/kafka/router.pyi
+++ b/faststream/kafka/router.pyi
@@ -1,14 +1,4 @@
-from typing import (
-    Any,
-    Awaitable,
-    Callable,
-    Dict,
-    Literal,
-    Optional,
-    Sequence,
-    TypeVar,
-    Union,
-)
+from typing import Any, Callable, Dict, Literal, Optional, Sequence, TypeVar, Union
 
 import aiokafka
 from fast_depends.dependencies import Depends
@@ -17,19 +7,19 @@ from kafka.coordinator.assignors.roundrobin import RoundRobinPartitionAssignor
 
 from faststream._compat import override
 from faststream.broker.core.asyncronous import default_filter
-from faststream.broker.message import StreamMessage
 from faststream.broker.middlewares import BaseMiddleware
 from faststream.broker.router import BrokerRouter
 from faststream.broker.types import (
-    AsyncCustomDecoder,
-    AsyncCustomParser,
+    CustomDecoder,
+    CustomParser,
+    Filter,
     P_HandlerParams,
     T_HandlerReturn,
 )
 from faststream.broker.wrapper import HandlerCallWrapper
 from faststream.kafka.asyncapi import Publisher
+from faststream.kafka.message import KafkaMessage
 
-KafkaMessage = StreamMessage[aiokafka.ConsumerRecord]
 Partition = TypeVar("Partition")
 
 class KafkaRouter(BrokerRouter[str, aiokafka.ConsumerRecord]):
@@ -93,8 +83,8 @@ class KafkaRouter(BrokerRouter[str, aiokafka.ConsumerRecord]):
         ] = "read_uncommitted",
         # broker arguments
         dependencies: Sequence[Depends] = (),
-        parser: Optional[AsyncCustomParser[aiokafka.ConsumerRecord]] = None,
-        decoder: Optional[AsyncCustomDecoder[aiokafka.ConsumerRecord]] = None,
+        parser: Optional[CustomParser[aiokafka.ConsumerRecord]] = None,
+        decoder: Optional[CustomDecoder[aiokafka.ConsumerRecord]] = None,
         middlewares: Optional[
             Sequence[
                 Callable[
@@ -103,9 +93,7 @@ class KafkaRouter(BrokerRouter[str, aiokafka.ConsumerRecord]):
                 ]
             ]
         ] = None,
-        filter: Union[
-            Callable[[KafkaMessage], bool], Callable[[KafkaMessage], Awaitable[bool]]
-        ] = default_filter,
+        filter: Filter[KafkaMessage] = default_filter,
         batch: bool = False,
         max_records: Optional[int] = None,
         batch_timeout_ms: int = 200,

--- a/faststream/kafka/shared/router.pyi
+++ b/faststream/kafka/shared/router.pyi
@@ -1,6 +1,5 @@
-from typing import Any, Awaitable, Callable, Literal, Optional, Sequence, Union
+from typing import Any, Callable, Literal, Optional, Sequence, Tuple, Union, overload
 
-import aio_pika
 import aiokafka
 from fast_depends.dependencies import Depends
 from kafka.coordinator.assignors.abstract import AbstractPartitionAssignor
@@ -9,18 +8,13 @@ from kafka.coordinator.assignors.roundrobin import RoundRobinPartitionAssignor
 from faststream.broker.core.asyncronous import default_filter
 from faststream.broker.message import StreamMessage
 from faststream.broker.middlewares import BaseMiddleware
-from faststream.broker.types import (
-    AsyncCustomDecoder,
-    AsyncCustomParser,
-    T_HandlerReturn,
-)
-
-KafkaMessage = StreamMessage[aiokafka.ConsumerRecord]
-RabbitMessage = StreamMessage[aio_pika.IncomingMessage]
+from faststream.broker.types import CustomDecoder, CustomParser, Filter, T_HandlerReturn
+from faststream.kafka.message import KafkaMessage
 
 class KafkaRoute:
     """Delayed `KafkaBroker.subscriber()` registration object"""
 
+    @overload
     def __init__(
         self,
         call: Callable[..., T_HandlerReturn],
@@ -56,8 +50,8 @@ class KafkaRoute:
         ] = "read_uncommitted",
         # broker arguments
         dependencies: Sequence[Depends] = (),
-        parser: Optional[AsyncCustomParser[aiokafka.ConsumerRecord]] = None,
-        decoder: Optional[AsyncCustomDecoder[aiokafka.ConsumerRecord]] = None,
+        parser: Optional[CustomParser[Tuple[aiokafka.ConsumerRecord, ...]]] = None,
+        decoder: Optional[CustomDecoder[Tuple[aiokafka.ConsumerRecord, ...]]] = None,
         middlewares: Optional[
             Sequence[
                 Callable[
@@ -66,10 +60,66 @@ class KafkaRoute:
                 ]
             ]
         ] = None,
-        filter: Union[
-            Callable[[KafkaMessage], bool], Callable[[KafkaMessage], Awaitable[bool]]
+        filter: Filter[
+            StreamMessage[Tuple[aiokafka.ConsumerRecord, ...]]
         ] = default_filter,
-        batch: bool = False,
+        batch: Literal[True] = True,
+        max_records: Optional[int] = None,
+        batch_timeout_ms: int = 200,
+        retry: Union[bool, int] = False,
+        # AsyncAPI information
+        title: Optional[str] = None,
+        description: Optional[str] = None,
+        **__service_kwargs: Any,
+    ) -> None: ...
+    @overload
+    def __init__(
+        self,
+        call: Callable[..., T_HandlerReturn],
+        *topics: str,
+        group_id: Optional[str] = None,
+        key_deserializer: Optional[Callable[[bytes], Any]] = None,
+        value_deserializer: Optional[Callable[[bytes], Any]] = None,
+        fetch_max_wait_ms: int = 500,
+        fetch_max_bytes: int = 52428800,
+        fetch_min_bytes: int = 1,
+        max_partition_fetch_bytes: int = 1 * 1024 * 1024,
+        auto_offset_reset: Literal[
+            "latest",
+            "earliest",
+            "none",
+        ] = "latest",
+        enable_auto_commit: bool = True,
+        auto_commit_interval_ms: int = 5000,
+        check_crcs: bool = True,
+        partition_assignment_strategy: Sequence[AbstractPartitionAssignor] = (
+            RoundRobinPartitionAssignor,
+        ),
+        max_poll_interval_ms: int = 300000,
+        rebalance_timeout_ms: Optional[int] = None,
+        session_timeout_ms: int = 10000,
+        heartbeat_interval_ms: int = 3000,
+        consumer_timeout_ms: int = 200,
+        max_poll_records: Optional[int] = None,
+        exclude_internal_topics: bool = True,
+        isolation_level: Literal[
+            "read_uncommitted",
+            "read_committed",
+        ] = "read_uncommitted",
+        # broker arguments
+        dependencies: Sequence[Depends] = (),
+        parser: Optional[CustomParser[aiokafka.ConsumerRecord]] = None,
+        decoder: Optional[CustomDecoder[aiokafka.ConsumerRecord]] = None,
+        middlewares: Optional[
+            Sequence[
+                Callable[
+                    [aiokafka.ConsumerRecord],
+                    BaseMiddleware,
+                ]
+            ]
+        ] = None,
+        filter: Filter[KafkaMessage] = default_filter,
+        batch: Literal[False] = False,
         max_records: Optional[int] = None,
         batch_timeout_ms: int = 200,
         retry: Union[bool, int] = False,

--- a/faststream/kafka/shared/schemas.py
+++ b/faststream/kafka/shared/schemas.py
@@ -4,11 +4,11 @@ from typing import List, Literal, Optional, Union
 
 from aiokafka.abc import AbstractTokenProvider
 
-from faststream._compat import TypedDict
+from faststream._compat import Required, TypedDict
 
 
 class ConsumerConnectionParams(TypedDict, total=False):
-    bootstrap_servers: Union[str, List[str]]
+    bootstrap_servers: Required[Union[str, List[str]]]
     loop: Optional[AbstractEventLoop]
     client_id: str
     request_timeout_ms: int

--- a/faststream/kafka/shared/schemas.py
+++ b/faststream/kafka/shared/schemas.py
@@ -27,9 +27,9 @@ class ConsumerConnectionParams(TypedDict, total=False):
         "SCRAM-SHA-512",
         "OAUTHBEARER",
     ]
-    sasl_plain_password: Optional[str]
-    sasl_plain_username: Optional[str]
+    sasl_plain_password: str
+    sasl_plain_username: str
     sasl_kerberos_service_name: str
-    sasl_kerberos_domain_name: Optional[str]
-    ssl_conext: Optional[ssl.SSLContext]
-    sasl_oauth_token_provider: Optional[AbstractTokenProvider]
+    sasl_kerberos_domain_name: str
+    ssl_conext: ssl.SSLContext
+    sasl_oauth_token_provider: AbstractTokenProvider

--- a/faststream/rabbit/broker.py
+++ b/faststream/rabbit/broker.py
@@ -13,9 +13,10 @@ from faststream.broker.message import StreamMessage
 from faststream.broker.middlewares import BaseMiddleware
 from faststream.broker.push_back_watcher import BaseWatcher, WatcherContext
 from faststream.broker.types import (
-    AsyncCustomDecoder,
-    AsyncCustomParser,
     AsyncPublisherProtocol,
+    CustomDecoder,
+    CustomParser,
+    Filter,
     P_HandlerParams,
     T_HandlerReturn,
     WrappedReturn,
@@ -23,6 +24,7 @@ from faststream.broker.types import (
 from faststream.broker.wrapper import FakePublisher, HandlerCallWrapper
 from faststream.rabbit.asyncapi import Handler, Publisher
 from faststream.rabbit.helpers import RabbitDeclarer
+from faststream.rabbit.message import RabbitMessage
 from faststream.rabbit.producer import AioPikaFastProducer
 from faststream.rabbit.shared.constants import RABBIT_REPLY
 from faststream.rabbit.shared.logging import RabbitLoggingMixin
@@ -35,8 +37,6 @@ from faststream.rabbit.shared.types import TimeoutType
 from faststream.types import AnyDict, SendableMessage
 from faststream.utils import context
 from faststream.utils.functions import to_async
-
-RabbitMessage = StreamMessage[aio_pika.IncomingMessage]
 
 
 class RabbitBroker(
@@ -159,14 +159,12 @@ class RabbitBroker(
         consume_args: Optional[AnyDict] = None,
         # broker arguments
         dependencies: Sequence[Depends] = (),
-        parser: Optional[AsyncCustomParser[aio_pika.IncomingMessage]] = None,
-        decoder: Optional[AsyncCustomDecoder[aio_pika.IncomingMessage]] = None,
+        parser: Optional[CustomParser[aio_pika.IncomingMessage]] = None,
+        decoder: Optional[CustomDecoder[aio_pika.IncomingMessage]] = None,
         middlewares: Optional[
             Sequence[Callable[[aio_pika.IncomingMessage], BaseMiddleware]]
         ] = None,
-        filter: Union[
-            Callable[[RabbitMessage], bool], Callable[[RabbitMessage], Awaitable[bool]]
-        ] = default_filter,
+        filter: Filter[RabbitMessage] = default_filter,
         # AsyncAPI information
         title: Optional[str] = None,
         description: Optional[str] = None,
@@ -272,9 +270,14 @@ class RabbitBroker(
 
     def _process_message(
         self,
-        func: Callable[[RabbitMessage], Awaitable[T_HandlerReturn]],
+        func: Callable[
+            [StreamMessage[aio_pika.IncomingMessage]], Awaitable[T_HandlerReturn]
+        ],
         watcher: BaseWatcher,
-    ) -> Callable[[RabbitMessage], Awaitable[WrappedReturn[T_HandlerReturn]],]:
+    ) -> Callable[
+        [StreamMessage[aio_pika.IncomingMessage]],
+        Awaitable[WrappedReturn[T_HandlerReturn]],
+    ]:
         @wraps(func)
         async def process_wrapper(
             message: RabbitMessage,

--- a/faststream/rabbit/fastapi.pyi
+++ b/faststream/rabbit/fastapi.pyi
@@ -21,7 +21,6 @@ from fastapi.datastructures import Default
 from fastapi.routing import APIRoute
 from fastapi.utils import generate_unique_id
 from pamqp.common import FieldTable
-from pydantic import AnyHttpUrl
 from starlette import routing
 from starlette.responses import JSONResponse, Response
 from starlette.types import AppType, ASGIApp
@@ -31,22 +30,21 @@ from faststream._compat import override
 from faststream.asyncapi import schema as asyncapi
 from faststream.broker.core.asyncronous import default_filter
 from faststream.broker.fastapi.router import StreamRouter
-from faststream.broker.message import StreamMessage
 from faststream.broker.middlewares import BaseMiddleware
 from faststream.broker.types import (
-    AsyncCustomDecoder,
-    AsyncCustomParser,
+    CustomDecoder,
+    CustomParser,
+    Filter,
     P_HandlerParams,
     T_HandlerReturn,
 )
 from faststream.broker.wrapper import HandlerCallWrapper
 from faststream.rabbit.asyncapi import Publisher
 from faststream.rabbit.broker import RabbitBroker
+from faststream.rabbit.message import RabbitMessage
 from faststream.rabbit.shared.schemas import RabbitExchange, RabbitQueue
 from faststream.rabbit.shared.types import TimeoutType
 from faststream.types import AnyDict
-
-RabbitMessage = StreamMessage[aio_pika.IncomingMessage]
 
 class RabbitRouter(StreamRouter[IncomingMessage]):
     broker_class: Type[RabbitBroker]
@@ -69,29 +67,16 @@ class RabbitRouter(StreamRouter[IncomingMessage]):
         # specific args
         max_consumers: Optional[int] = None,
         # Broker kwargs
-        decoder: Optional[AsyncCustomDecoder[aio_pika.IncomingMessage]] = None,
-        parser: Optional[AsyncCustomParser[aio_pika.IncomingMessage]] = None,
+        decoder: Optional[CustomDecoder[aio_pika.IncomingMessage]] = None,
+        parser: Optional[CustomParser[aio_pika.IncomingMessage]] = None,
         middlewares: Optional[
             Sequence[Callable[[aio_pika.IncomingMessage], BaseMiddleware]]
         ] = None,
         # AsyncAPI args
-        title: str = "FastStream",
-        version: str = "0.1.0",
-        description: str = "",
-        terms_of_service: Optional[AnyHttpUrl] = None,
-        license: Optional[
-            Union[asyncapi.License, asyncapi.LicenseDict, AnyDict]
-        ] = None,
-        contact: Optional[
-            Union[asyncapi.Contact, asyncapi.ContactDict, AnyDict]
-        ] = None,
-        identifier: Optional[str] = None,
-        asyncapi_tags: Optional[
-            List[Union[asyncapi.Tag, asyncapi.TagDict, AnyDict]]
-        ] = None,
-        external_docs: Optional[
-            Union[asyncapi.ExternalDocs, asyncapi.ExternalDocsDict, AnyDict]
-        ] = None,
+        protocol: str = "amqp",
+        protocol_version: Optional[str] = "0.9.1",
+        description: Optional[str] = None,
+        asyncapi_tags: Optional[Sequence[asyncapi.Tag]] = None,
         schema_url: Optional[str] = "/asyncapi",
         # FastAPI kwargs
         prefix: str = "",
@@ -123,11 +108,9 @@ class RabbitRouter(StreamRouter[IncomingMessage]):
         consume_args: Optional[AnyDict] = None,
         # broker arguments
         dependencies: Sequence[params.Depends] = (),
-        filter: Union[
-            Callable[[RabbitMessage], bool], Callable[[RabbitMessage], Awaitable[bool]]
-        ] = default_filter,
-        parser: Optional[AsyncCustomParser[aio_pika.IncomingMessage]] = None,
-        decoder: Optional[AsyncCustomDecoder[aio_pika.IncomingMessage]] = None,
+        filter: Filter[RabbitMessage] = default_filter,
+        parser: Optional[CustomParser[aio_pika.IncomingMessage]] = None,
+        decoder: Optional[CustomDecoder[aio_pika.IncomingMessage]] = None,
         middlewares: Optional[
             Sequence[Callable[[aio_pika.IncomingMessage], BaseMiddleware]]
         ] = None,
@@ -147,11 +130,9 @@ class RabbitRouter(StreamRouter[IncomingMessage]):
         consume_args: Optional[AnyDict] = None,
         # broker arguments
         dependencies: Sequence[params.Depends] = (),
-        filter: Union[
-            Callable[[RabbitMessage], bool], Callable[[RabbitMessage], Awaitable[bool]]
-        ] = default_filter,
-        parser: Optional[AsyncCustomParser[aio_pika.IncomingMessage]] = None,
-        decoder: Optional[AsyncCustomDecoder[aio_pika.IncomingMessage]] = None,
+        filter: Filter[RabbitMessage] = default_filter,
+        parser: Optional[CustomParser[aio_pika.IncomingMessage]] = None,
+        decoder: Optional[CustomDecoder[aio_pika.IncomingMessage]] = None,
         middlewares: Optional[
             Sequence[Callable[[aio_pika.IncomingMessage], BaseMiddleware]]
         ] = None,

--- a/faststream/rabbit/fastapi.pyi
+++ b/faststream/rabbit/fastapi.pyi
@@ -21,6 +21,7 @@ from fastapi.datastructures import Default
 from fastapi.routing import APIRoute
 from fastapi.utils import generate_unique_id
 from pamqp.common import FieldTable
+from pydantic import AnyHttpUrl
 from starlette import routing
 from starlette.responses import JSONResponse, Response
 from starlette.types import AppType, ASGIApp
@@ -67,6 +68,31 @@ class RabbitRouter(StreamRouter[IncomingMessage]):
         client_properties: Optional[FieldTable] = None,
         # specific args
         max_consumers: Optional[int] = None,
+        # Broker kwargs
+        decoder: Optional[AsyncCustomDecoder[aio_pika.IncomingMessage]] = None,
+        parser: Optional[AsyncCustomParser[aio_pika.IncomingMessage]] = None,
+        middlewares: Optional[
+            Sequence[Callable[[aio_pika.IncomingMessage], BaseMiddleware]]
+        ] = None,
+        # AsyncAPI args
+        title: str = "FastStream",
+        version: str = "0.1.0",
+        description: str = "",
+        terms_of_service: Optional[AnyHttpUrl] = None,
+        license: Optional[
+            Union[asyncapi.License, asyncapi.LicenseDict, AnyDict]
+        ] = None,
+        contact: Optional[
+            Union[asyncapi.Contact, asyncapi.ContactDict, AnyDict]
+        ] = None,
+        identifier: Optional[str] = None,
+        asyncapi_tags: Optional[
+            List[Union[asyncapi.Tag, asyncapi.TagDict, AnyDict]]
+        ] = None,
+        external_docs: Optional[
+            Union[asyncapi.ExternalDocs, asyncapi.ExternalDocsDict, AnyDict]
+        ] = None,
+        schema_url: Optional[str] = "/asyncapi",
         # FastAPI kwargs
         prefix: str = "",
         tags: Optional[List[Union[str, Enum]]] = None,
@@ -86,17 +112,6 @@ class RabbitRouter(StreamRouter[IncomingMessage]):
         generate_unique_id_function: Callable[[APIRoute], str] = Default(
             generate_unique_id
         ),
-        # Broker kwargs
-        decoder: Optional[AsyncCustomDecoder[aio_pika.IncomingMessage]] = None,
-        parser: Optional[AsyncCustomParser[aio_pika.IncomingMessage]] = None,
-        middlewares: Optional[
-            Sequence[Callable[[aio_pika.IncomingMessage], BaseMiddleware]]
-        ] = None,
-        # AsyncAPI args
-        protocol: str = "amqp",
-        protocol_version: Optional[str] = "0.9.1",
-        description: Optional[str] = None,
-        asyncapi_tags: Optional[Sequence[asyncapi.Tag]] = None,
     ) -> None:
         pass
     def add_api_mq_route(  # type: ignore[override]

--- a/faststream/rabbit/router.pyi
+++ b/faststream/rabbit/router.pyi
@@ -1,27 +1,26 @@
-from typing import Any, Awaitable, Callable, Optional, Sequence, Union
+from typing import Any, Callable, Optional, Sequence, Union
 
 import aio_pika
 from fast_depends.dependencies import Depends
 
 from faststream._compat import override
 from faststream.broker.core.asyncronous import default_filter
-from faststream.broker.message import StreamMessage
 from faststream.broker.middlewares import BaseMiddleware
 from faststream.broker.router import BrokerRouter
 from faststream.broker.types import (
-    AsyncCustomDecoder,
-    AsyncCustomParser,
+    CustomDecoder,
+    CustomParser,
+    Filter,
     P_HandlerParams,
     T_HandlerReturn,
 )
 from faststream.broker.wrapper import HandlerCallWrapper
 from faststream.rabbit.asyncapi import Publisher
+from faststream.rabbit.message import RabbitMessage
 from faststream.rabbit.shared.router import RabbitRoute
 from faststream.rabbit.shared.schemas import RabbitExchange, RabbitQueue
 from faststream.rabbit.shared.types import TimeoutType
 from faststream.types import AnyDict
-
-RabbitMessage = StreamMessage[aio_pika.IncomingMessage]
 
 class RabbitRouter(BrokerRouter[int, aio_pika.IncomingMessage]):
     def __init__(
@@ -33,8 +32,8 @@ class RabbitRouter(BrokerRouter[int, aio_pika.IncomingMessage]):
         middlewares: Optional[
             Sequence[Callable[[aio_pika.IncomingMessage], BaseMiddleware]]
         ] = None,
-        parser: Optional[AsyncCustomParser[aio_pika.IncomingMessage]] = None,
-        decoder: Optional[AsyncCustomDecoder[aio_pika.IncomingMessage]] = None,
+        parser: Optional[CustomParser[aio_pika.IncomingMessage]] = None,
+        decoder: Optional[CustomDecoder[aio_pika.IncomingMessage]] = None,
     ): ...
     @staticmethod
     @override
@@ -54,11 +53,9 @@ class RabbitRouter(BrokerRouter[int, aio_pika.IncomingMessage]):
         consume_args: Optional[AnyDict] = None,
         # broker arguments
         dependencies: Sequence[Depends] = (),
-        filter: Union[
-            Callable[[RabbitMessage], bool], Callable[[RabbitMessage], Awaitable[bool]]
-        ] = default_filter,
-        parser: Optional[AsyncCustomParser[aio_pika.IncomingMessage]] = None,
-        decoder: Optional[AsyncCustomDecoder[aio_pika.IncomingMessage]] = None,
+        filter: Filter[RabbitMessage] = default_filter,
+        parser: Optional[CustomParser[aio_pika.IncomingMessage]] = None,
+        decoder: Optional[CustomDecoder[aio_pika.IncomingMessage]] = None,
         middlewares: Optional[
             Sequence[
                 Callable[

--- a/faststream/rabbit/shared/router.pyi
+++ b/faststream/rabbit/shared/router.pyi
@@ -1,20 +1,19 @@
-from typing import Any, Awaitable, Callable, Optional, Sequence, Union
+from typing import Any, Callable, Optional, Sequence, Union
 
 import aio_pika
 from fast_depends.dependencies import Depends
 
 from faststream.broker.core.asyncronous import default_filter
-from faststream.broker.message import StreamMessage
 from faststream.broker.middlewares import BaseMiddleware
 from faststream.broker.types import (
     AsyncCustomDecoder,
     AsyncCustomParser,
+    Filter,
     T_HandlerReturn,
 )
+from faststream.rabbit.message import RabbitMessage
 from faststream.rabbit.shared.schemas import RabbitExchange, RabbitQueue
 from faststream.types import AnyDict
-
-RabbitMessage = StreamMessage[aio_pika.IncomingMessage]
 
 class RabbitRoute:
     """Delayed `RabbitBroker.subscriber()` registration object"""
@@ -28,9 +27,7 @@ class RabbitRoute:
         consume_args: Optional[AnyDict] = None,
         # broker arguments
         dependencies: Sequence[Depends] = (),
-        filter: Union[
-            Callable[[RabbitMessage], bool], Callable[[RabbitMessage], Awaitable[bool]]
-        ] = default_filter,
+        filter: Filter[RabbitMessage] = default_filter,
         parser: Optional[AsyncCustomParser[aio_pika.IncomingMessage]] = None,
         decoder: Optional[AsyncCustomDecoder[aio_pika.IncomingMessage]] = None,
         middlewares: Optional[

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -95,6 +95,7 @@ testing = [
     "fastapi>=0.100.0b",
     "pydantic-settings",
     "httpx",
+    "PyYAML",
 ]
 
 dev = ["faststream[rabbit,kafka,docs,lint,testing,devdocs]"]

--- a/tests/asyncapi/base/fastapi.py
+++ b/tests/asyncapi/base/fastapi.py
@@ -2,7 +2,6 @@ from typing import Any, Callable, Type
 
 from fastapi import FastAPI
 from fastapi.testclient import TestClient
-from loguru import logger
 
 from faststream.asyncapi.generate import get_app_schema
 from faststream.broker.core.abc import BrokerUsecase
@@ -16,7 +15,6 @@ class FastAPITestCase:
 
     def test_fastapi_asyncapi_routes(self):
         broker = self.broker_class(schema_url="/asyncapi_schema")
-        logger.debug(broker)
         broker.broker = self.broker_wrapper(broker.broker)
 
         @broker.subscriber("test")
@@ -26,7 +24,6 @@ class FastAPITestCase:
         app = FastAPI(lifespan=broker.lifespan_context)
         app.include_router(broker)
 
-        logger.debug(broker)
         schema = get_app_schema(broker)
 
         with TestClient(app) as client:

--- a/tests/asyncapi/base/fastapi.py
+++ b/tests/asyncapi/base/fastapi.py
@@ -44,8 +44,8 @@ class FastAPITestCase:
                     "title": "CustomApp",
                     "version": "1.1.1",
                     "description": "Test description",
-                    "contact": {"name": "support", "url": IsStr(regex=r"https://support.com")},
-                    "license": {"name": "some", "url": IsStr(regex=r"https://some.com")},
+                    "contact": {"name": "support", "url": IsStr(regex=r"https\:\/\/support\.com\/?")},
+                    "license": {"name": "some", "url": IsStr(regex=r"https\:\/\/some\.com\/?")},
                 },
                 "servers": {
                     "development": {

--- a/tests/asyncapi/base/fastapi.py
+++ b/tests/asyncapi/base/fastapi.py
@@ -1,8 +1,8 @@
 from typing import Any, Callable, Type
 
-from dirty_equals import IsStr
 from fastapi import FastAPI
 from fastapi.testclient import TestClient
+from dirty_equals import IsStr
 
 from faststream.asyncapi.generate import get_app_schema
 from faststream.broker.core.abc import BrokerUsecase
@@ -44,8 +44,8 @@ class FastAPITestCase:
                     "title": "CustomApp",
                     "version": "1.1.1",
                     "description": "Test description",
-                    "contact": {"name": "support", "url": "https://support.com/"},
-                    "license": {"name": "some", "url": "https://some.com/"},
+                    "contact": {"name": "support", "url": IsStr(regex=r"https://support.com")},
+                    "license": {"name": "some", "url": IsStr(regex=r"https://some.com")},
                 },
                 "servers": {
                     "development": {

--- a/tests/asyncapi/base/fastapi.py
+++ b/tests/asyncapi/base/fastapi.py
@@ -1,0 +1,72 @@
+from typing import Any, Callable, Type
+
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+from loguru import logger
+
+from faststream.asyncapi.generate import get_app_schema
+from faststream.broker.core.abc import BrokerUsecase
+from faststream.broker.fastapi.router import StreamRouter
+from faststream.broker.types import MsgType
+
+
+class FastAPITestCase:
+    broker_class: Type[StreamRouter[MsgType]]
+    broker_wrapper: Callable[[BrokerUsecase[MsgType, Any]], BrokerUsecase[MsgType, Any]]
+
+    def test_fastapi_asyncapi_routes(self):
+        broker = self.broker_class(schema_url="/asyncapi_schema")
+        logger.debug(broker)
+        broker.broker = self.broker_wrapper(broker.broker)
+
+        @broker.subscriber("test")
+        async def handler():
+            ...
+
+        app = FastAPI(lifespan=broker.lifespan_context)
+        app.include_router(broker)
+
+        logger.debug(broker)
+        schema = get_app_schema(broker)
+
+        with TestClient(app) as client:
+            response_json = client.get("/asyncapi_schema.json")
+            assert response_json.json() == schema.to_jsonable()
+
+            response_yaml = client.get("/asyncapi_schema.yaml")
+            assert response_yaml.text == schema.to_yaml()
+
+            response_html = client.get("/asyncapi_schema")
+            assert response_html.status_code == 200
+
+    def test_fastapi_asyncapi_not_fount(self):
+        broker = self.broker_class(include_in_schema=False)
+        broker.broker = self.broker_wrapper(broker.broker)
+        app = FastAPI(lifespan=broker.lifespan_context)
+        app.include_router(broker)
+
+        with TestClient(app) as client:
+            response_json = client.get("/asyncapi.json")
+            assert response_json.status_code == 404
+
+            response_yaml = client.get("/asyncapi.yaml")
+            assert response_yaml.status_code == 404
+
+            response_html = client.get("/asyncapi")
+            assert response_html.status_code == 404
+
+    def test_fastapi_asyncapi_not_fount_by_url(self):
+        broker = self.broker_class(schema_url=None)
+        broker.broker = self.broker_wrapper(broker.broker)
+        app = FastAPI(lifespan=broker.lifespan_context)
+        app.include_router(broker)
+
+        with TestClient(app) as client:
+            response_json = client.get("/asyncapi.json")
+            assert response_json.status_code == 404
+
+            response_yaml = client.get("/asyncapi.yaml")
+            assert response_yaml.status_code == 404
+
+            response_html = client.get("/asyncapi")
+            assert response_html.status_code == 404

--- a/tests/asyncapi/kafka/test_fastapi.py
+++ b/tests/asyncapi/kafka/test_fastapi.py
@@ -1,10 +1,15 @@
+from typing import Type
+
 from faststream.kafka.fastapi import KafkaRouter
+from faststream.kafka.test import TestKafkaBroker
 from tests.asyncapi.base.arguments import FastAPICompatible
+from tests.asyncapi.base.fastapi import FastAPITestCase
 from tests.asyncapi.base.publisher import PublisherTestcase
 
 
-class TestRouterArguments(FastAPICompatible):
-    broker_class = KafkaRouter
+class TestRouterArguments(FastAPITestCase, FastAPICompatible):
+    broker_class: Type[KafkaRouter] = KafkaRouter
+    broker_wrapper = staticmethod(TestKafkaBroker)
 
     def build_app(self, router):
         return router

--- a/tests/asyncapi/rabbit/test_fastapi.py
+++ b/tests/asyncapi/rabbit/test_fastapi.py
@@ -1,10 +1,15 @@
+from typing import Type
+
 from faststream.rabbit.fastapi import RabbitRouter
+from faststream.rabbit.test import TestRabbitBroker
 from tests.asyncapi.base.arguments import FastAPICompatible
+from tests.asyncapi.base.fastapi import FastAPITestCase
 from tests.asyncapi.base.publisher import PublisherTestcase
 
 
-class TestRouterArguments(FastAPICompatible):
-    broker_class = RabbitRouter
+class TestRouterArguments(FastAPITestCase, FastAPICompatible):
+    broker_class: Type[RabbitRouter] = RabbitRouter
+    broker_wrapper = staticmethod(TestRabbitBroker)
 
     def build_app(self, router):
         return router


### PR DESCRIPTION
There two features in this PR

The first one can be described by this test: https://github.com/airtai/fastkafka/blob/FastAPI-AsyncAPI/tests/asyncapi/base/fastapi.py#L17

This is the FastAPI compatible way to setup AsyncAPI information with the FastStream plugin. Also, it adds 3 routes `/asyncapi`, `/asyncapi.json` and `/asyncapi.yaml` to interact with the AsyncAPI scheme right from the FastAPI application

The next feature is much simpler custom decoder/parser support

For now, the following examples are valid decoders/encoders too

```python
def decode(msg):
    ...

async def decode(msg):
    ...

async def decode(msg, original):
    return await original(msg)
```

In the old version, only the last one was valid function