### PR TITLE
feat: add FastAPI Router include_router method, fix #497

### DIFF
--- a/faststream/kafka/fastapi.py
+++ b/faststream/kafka/fastapi.py
@@ -6,3 +6,11 @@ from faststream.kafka.broker import KafkaBroker
 
 class KafkaRouter(StreamRouter[ConsumerRecord]):
     broker_class = KafkaBroker
+
+    @staticmethod
+    def _setup_log_context(
+        main_broker: KafkaBroker,
+        including_broker: KafkaBroker,
+    ) -> None:
+        for h in including_broker.handlers.values():
+            main_broker._setup_log_context(h.topics)

--- a/faststream/kafka/fastapi.pyi
+++ b/faststream/kafka/fastapi.pyi
@@ -34,7 +34,7 @@ from kafka.coordinator.assignors.roundrobin import RoundRobinPartitionAssignor
 from kafka.partitioner.default import DefaultPartitioner
 from starlette import routing
 from starlette.responses import JSONResponse, Response
-from starlette.types import AppType, ASGIApp
+from starlette.types import AppType, ASGIApp, Lifespan
 
 from faststream.__about__ import __version__
 from faststream._compat import override
@@ -122,6 +122,7 @@ class KafkaRouter(StreamRouter[ConsumerRecord]):
         on_shutdown: Optional[Sequence[Callable[[], Any]]] = None,
         deprecated: Optional[bool] = None,
         include_in_schema: bool = True,
+        lifespan: Optional[Lifespan[Any]] = None,
         generate_unique_id_function: Callable[[APIRoute], str] = Default(
             generate_unique_id
         ),
@@ -421,3 +422,9 @@ class KafkaRouter(StreamRouter[ConsumerRecord]):
         self,
         func: Callable[[AppType], Awaitable[None]],
     ) -> Callable[[AppType], Awaitable[None]]: ...
+    @override
+    @staticmethod
+    def _setup_log_context(  # type: ignore[override]
+        main_broker: KafkaBroker,
+        including_broker: KafkaBroker,
+    ) -> None: ...

--- a/faststream/rabbit/fastapi.py
+++ b/faststream/rabbit/fastapi.py
@@ -6,3 +6,11 @@ from faststream.rabbit.broker import RabbitBroker
 
 class RabbitRouter(StreamRouter[IncomingMessage]):
     broker_class = RabbitBroker
+
+    @staticmethod
+    def _setup_log_context(
+        main_broker: RabbitBroker,
+        including_broker: RabbitBroker,
+    ) -> None:
+        for h in including_broker.handlers.values():
+            main_broker._setup_log_context(h.queue, h.exchange)

--- a/faststream/rabbit/fastapi.pyi
+++ b/faststream/rabbit/fastapi.pyi
@@ -23,7 +23,7 @@ from fastapi.utils import generate_unique_id
 from pamqp.common import FieldTable
 from starlette import routing
 from starlette.responses import JSONResponse, Response
-from starlette.types import AppType, ASGIApp
+from starlette.types import AppType, ASGIApp, Lifespan
 from yarl import URL
 
 from faststream._compat import override
@@ -49,7 +49,6 @@ from faststream.types import AnyDict
 class RabbitRouter(StreamRouter[IncomingMessage]):
     broker_class: Type[RabbitBroker]
 
-    # nosemgrep: python.lang.security.audit.hardcoded-password-default-argument.hardcoded-password-default-argument
     def __init__(
         self,
         url: Union[str, URL, None] = "amqp://guest:guest@localhost:5672/",
@@ -95,6 +94,7 @@ class RabbitRouter(StreamRouter[IncomingMessage]):
         on_shutdown: Optional[Sequence[Callable[[], Any]]] = None,
         deprecated: Optional[bool] = None,
         include_in_schema: bool = True,
+        lifespan: Optional[Lifespan[Any]] = None,
         generate_unique_id_function: Callable[[APIRoute], str] = Default(
             generate_unique_id
         ),
@@ -194,3 +194,9 @@ class RabbitRouter(StreamRouter[IncomingMessage]):
         self,
         func: Callable[[AppType], Awaitable[None]],
     ) -> Callable[[AppType], Awaitable[None]]: ...
+    @override
+    @staticmethod
+    def _setup_log_context(  # type: ignore[override]
+        main_broker: RabbitBroker,
+        including_broker: RabbitBroker,
+    ) -> None: ...

--- a/faststream/rabbit/fastapi.pyi
+++ b/faststream/rabbit/fastapi.pyi
@@ -49,6 +49,7 @@ from faststream.types import AnyDict
 class RabbitRouter(StreamRouter[IncomingMessage]):
     broker_class: Type[RabbitBroker]
 
+    # nosemgrep: python.lang.security.audit.hardcoded-password-default-argument.hardcoded-password-default-argument
     def __init__(
         self,
         url: Union[str, URL, None] = "amqp://guest:guest@localhost:5672/",

--- a/tests/asyncapi/base/fastapi.py
+++ b/tests/asyncapi/base/fastapi.py
@@ -44,14 +44,8 @@ class FastAPITestCase:
                     "title": "CustomApp",
                     "version": "1.1.1",
                     "description": "Test description",
-                    "contact": {
-                        "name": "support",
-                        "url": IsStr(regex=r"https\:\/\/support\.com\/?"),
-                    },
-                    "license": {
-                        "name": "some",
-                        "url": IsStr(regex=r"https\:\/\/some\.com\/?"),
-                    },
+                    "contact": {"name": "support", "url": "https://support.com/"},
+                    "license": {"name": "some", "url": "https://some.com/"},
                 },
                 "servers": {
                     "development": {

--- a/tests/asyncapi/base/fastapi.py
+++ b/tests/asyncapi/base/fastapi.py
@@ -44,8 +44,14 @@ class FastAPITestCase:
                     "title": "CustomApp",
                     "version": "1.1.1",
                     "description": "Test description",
-                    "contact": {"name": "support", "url": "https://support.com/"},
-                    "license": {"name": "some", "url": "https://some.com/"},
+                    "contact": {
+                        "name": "support",
+                        "url": IsStr(regex=r"https\:\/\/support\.com\/?"),
+                    },
+                    "license": {
+                        "name": "some",
+                        "url": IsStr(regex=r"https\:\/\/some\.com\/?"),
+                    },
                 },
                 "servers": {
                     "development": {

--- a/tests/brokers/base/consume.py
+++ b/tests/brokers/base/consume.py
@@ -1,5 +1,4 @@
 import asyncio
-from unittest.mock import Mock
 
 import pytest
 
@@ -17,26 +16,24 @@ class BrokerConsumeTestcase:
         self,
         queue: str,
         consume_broker: BrokerUsecase,
-        event: asyncio.Event,
     ):
         @consume_broker.subscriber(queue)
         def subscriber(m):
-            event.set()
+            ...
 
         await consume_broker.start()
         await asyncio.wait(
             (
                 asyncio.create_task(consume_broker.publish("hello", queue)),
-                asyncio.create_task(event.wait()),
+                asyncio.create_task(subscriber.wait_call()),
             ),
             timeout=3,
         )
 
-        assert event.is_set()
+        assert subscriber.event.is_set()
 
     async def test_consume_from_multi(
         self,
-        mock: Mock,
         queue: str,
         consume_broker: BrokerUsecase,
     ):
@@ -50,7 +47,6 @@ class BrokerConsumeTestcase:
                 consume.set()
             else:
                 consume2.set()
-            mock()
 
         await consume_broker.start()
         await asyncio.wait(
@@ -65,11 +61,10 @@ class BrokerConsumeTestcase:
 
         assert consume2.is_set()
         assert consume.is_set()
-        assert mock.call_count == 2
+        assert subscriber.mock.call_count == 2
 
     async def test_consume_double(
         self,
-        mock: Mock,
         queue: str,
         consume_broker: BrokerUsecase,
     ):
@@ -82,7 +77,6 @@ class BrokerConsumeTestcase:
                 consume.set()
             else:
                 consume2.set()
-            mock()
 
         await consume_broker.start()
 
@@ -98,28 +92,22 @@ class BrokerConsumeTestcase:
 
         assert consume2.is_set()
         assert consume.is_set()
-        assert mock.call_count == 2
+        assert handler.mock.call_count == 2
 
     async def test_different_consume(
         self,
-        mock: Mock,
         queue: str,
         consume_broker: BrokerUsecase,
     ):
-        first_consume = asyncio.Event()
-        second_consume = asyncio.Event()
-
         @consume_broker.subscriber(queue)
         def handler(m):
-            first_consume.set()
-            mock.method()
+            ...
 
         another_topic = queue + "1"
 
         @consume_broker.subscriber(another_topic)
         def handler2(m):
-            second_consume.set()
-            mock.method2()
+            ...
 
         await consume_broker.start()
 
@@ -127,37 +115,31 @@ class BrokerConsumeTestcase:
             (
                 asyncio.create_task(consume_broker.publish("hello", queue)),
                 asyncio.create_task(consume_broker.publish("hello", another_topic)),
-                asyncio.create_task(first_consume.wait()),
-                asyncio.create_task(second_consume.wait()),
+                asyncio.create_task(handler.wait_call()),
+                asyncio.create_task(handler2.wait_call()),
             ),
             timeout=3,
         )
 
-        assert first_consume.is_set()
-        assert second_consume.is_set()
-        mock.method.assert_called_once()
-        mock.method2.assert_called_once()
+        assert handler.event.is_set()
+        assert handler2.event.is_set()
+        handler.mock.assert_called_once()
+        handler2.mock.assert_called_once()
 
     async def test_consume_with_filter(
         self,
-        mock: Mock,
         queue: str,
         consume_broker: BrokerUsecase,
     ):
-        consume = asyncio.Event()
-        consume2 = asyncio.Event()
-
         @consume_broker.subscriber(
             queue, filter=lambda m: m.content_type == "application/json"
         )
         async def handler(m):
-            consume2.set()
-            mock.call1(m)
+            ...
 
         @consume_broker.subscriber(queue)
         async def handler2(m):
-            consume.set()
-            mock.call2(m)
+            ...
 
         await consume_broker.start()
 
@@ -165,16 +147,16 @@ class BrokerConsumeTestcase:
             (
                 asyncio.create_task(consume_broker.publish({"msg": "hello"}, queue)),
                 asyncio.create_task(consume_broker.publish("hello", queue)),
-                asyncio.create_task(consume.wait()),
-                asyncio.create_task(consume2.wait()),
+                asyncio.create_task(handler2.wait_call()),
+                asyncio.create_task(handler.wait_call()),
             ),
             timeout=3,
         )
 
-        assert consume2.is_set()
-        assert consume.is_set()
-        mock.call1.assert_called_once_with({"msg": "hello"})
-        mock.call2.assert_called_once_with("hello")
+        assert handler2.event.is_set()
+        assert handler2.event.is_set()
+        handler.mock.assert_called_once_with({"msg": "hello"})
+        handler2.mock.assert_called_once_with("hello")
 
 
 @pytest.mark.asyncio
@@ -183,21 +165,17 @@ class BrokerRealConsumeTestcase(BrokerConsumeTestcase):
     async def test_stop_consume_exc(
         self,
         queue: str,
-        mock: Mock,
         consume_broker: BrokerUsecase,
-        event: asyncio.Event,
     ):
         @consume_broker.subscriber(queue)
         def subscriber(m):
-            event.set()
-            mock()
             raise StopConsume()
 
         await consume_broker.start()
         await asyncio.wait(
             (
                 asyncio.create_task(consume_broker.publish("hello", queue)),
-                asyncio.create_task(event.wait()),
+                asyncio.create_task(subscriber.wait_call()),
             ),
             timeout=3,
         )
@@ -205,5 +183,5 @@ class BrokerRealConsumeTestcase(BrokerConsumeTestcase):
         await consume_broker.publish("hello", queue)
         await asyncio.sleep(0.5)
 
-        assert event.is_set()
-        mock.assert_called_once()
+        assert subscriber.event.is_set()
+        subscriber.mock.assert_called_once()

--- a/tests/brokers/base/rpc.py
+++ b/tests/brokers/base/rpc.py
@@ -1,6 +1,3 @@
-import asyncio
-from unittest.mock import Mock
-
 import anyio
 import pytest
 
@@ -58,15 +55,12 @@ class BrokerRPCTestcase:
         assert r is None
 
     @pytest.mark.asyncio
-    async def test_rpc_with_reply(
-        self, queue: str, mock: Mock, rpc_broker: BrokerUsecase, event: asyncio.Event
-    ):
+    async def test_rpc_with_reply(self, queue: str, rpc_broker: BrokerUsecase):
         reply_queue = queue + "1"
 
         @rpc_broker.subscriber(reply_queue)
         async def response_hanler(m: str):
-            event.set()
-            mock(m)
+            ...
 
         @rpc_broker.subscriber(queue)
         async def m(m):  # pragma: no cover
@@ -75,9 +69,9 @@ class BrokerRPCTestcase:
         await rpc_broker.start()
 
         await rpc_broker.publish("hello", queue, reply_to=reply_queue)
-        await asyncio.wait_for(event.wait(), 3)
+        await response_hanler.wait_call(3)
 
-        mock.assert_called_with("1")
+        response_hanler.mock.assert_called_with("1")
 
 
 class ReplyAndConsumeForbidden:

--- a/tests/brokers/kafka/test_test_client.py
+++ b/tests/brokers/kafka/test_test_client.py
@@ -33,7 +33,7 @@ class TestTestclient(BrokerTestclientTestcase):
             pass
 
         await test_broker.start()
-        await test_broker.publish("hello", topic=queue)
+        await test_broker.publish_batch("hello", topic=queue)
         m.mock.assert_called_once_with(["hello"])
 
     @pytest.mark.kafka

--- a/tests/brokers/kafka/test_test_client.py
+++ b/tests/brokers/kafka/test_test_client.py
@@ -9,6 +9,34 @@ from tests.brokers.base.testclient import BrokerTestclientTestcase
 @pytest.mark.asyncio
 class TestTestclient(BrokerTestclientTestcase):
     @pytest.mark.kafka
+    async def test_batch_pub_by_default_pub(
+        self,
+        test_broker: KafkaBroker,
+        queue: str,
+    ):
+        @test_broker.subscriber(queue, batch=True)
+        async def m():
+            pass
+
+        await test_broker.start()
+        await test_broker.publish("hello", queue)
+        m.mock.assert_called_once_with(["hello"])
+
+    @pytest.mark.kafka
+    async def test_batch_pub_by_pub_batch(
+        self,
+        test_broker: KafkaBroker,
+        queue: str,
+    ):
+        @test_broker.subscriber(queue, batch=True)
+        async def m():
+            pass
+
+        await test_broker.start()
+        await test_broker.publish("hello", topic=queue)
+        m.mock.assert_called_once_with(["hello"])
+
+    @pytest.mark.kafka
     async def test_with_real_testclient(
         self,
         broker: KafkaBroker,


### PR DESCRIPTION
Support FastAPI routers nesting:

```python
router = self.router_class()
router2 = self.router_class()
router.broker = self.broker_test(router.broker)

app = FastAPI(lifespan=router.lifespan_context)

@router.subscriber(queue)
async def hello():
    return "hi"

@router2.subscriber(queue + "1")
async def hello_router2():
    return "hi"

router.include_router(router2)
```

Fix `TestKafkaBroker.publish` and `publish_batch` methods to support batch consumers