### PR TITLE
Update asyncapi example URL

### DIFF
--- a/fastkafka/_components/docs_dependencies.py
+++ b/fastkafka/_components/docs_dependencies.py
@@ -161,7 +161,7 @@ async def _install_docs_npm_deps() -> None:
     """
     with TemporaryDirectory() as d:
         cmd = (
-            "npx -y -p @asyncapi/generator ag https://raw.githubusercontent.com/asyncapi/asyncapi/master/examples/simple.yml @asyncapi/html-template -o "
+            "npx -y -p @asyncapi/generator ag https://raw.githubusercontent.com/asyncapi/spec/master/examples/simple-asyncapi.yml @asyncapi/html-template -o "
             + d
         )
 

--- a/nbs/097_Docs_Dependencies.ipynb
+++ b/nbs/097_Docs_Dependencies.ipynb
@@ -397,7 +397,7 @@
     "    \"\"\"\n",
     "    with TemporaryDirectory() as d:\n",
     "        cmd = (\n",
-    "            \"npx -y -p @asyncapi/generator ag https://raw.githubusercontent.com/asyncapi/asyncapi/master/examples/simple.yml @asyncapi/html-template -o \"\n",
+    "            \"npx -y -p @asyncapi/generator ag https://raw.githubusercontent.com/asyncapi/spec/master/examples/simple-asyncapi.yml @asyncapi/html-template -o \"\n",
     "            + d\n",
     "        )\n",
     "\n",


### PR DESCRIPTION
asyncapi renamed their repo to spec and updated the example filename also - https://github.com/asyncapi/spec/tree/master/examples

We may have to make a release. 